### PR TITLE
Use correct index in process_notif_dev_connect

### DIFF
--- a/ltunify.c
+++ b/ltunify.c
@@ -427,7 +427,7 @@ bool process_notif_dev_connect(struct hidpp_message *msg, u8 *device_index,
 	if (device_index) *device_index = dev_idx;
 	if (is_new_device) *is_new_device = !dev->device_present;
 
-	memset(&devices[dev_idx], 0, sizeof devices[dev_idx]);
+	memset(dev, 0, sizeof *dev);
 	dev->device_type = dcon->device_info & DEVCON_DEV_TYPE_MASK;
 	dev->wireless_pid = (dcon->pid_msb << 8) | dcon->pid_lsb;
 	dev->device_present = true;


### PR DESCRIPTION
This fixes a crash that occasionally showed up when using `ltunify pair` or `ltunify unpair 6`, with the following stack trace:

```
Core was generated by `ltunify unpair 6'.                                                                                                                                                                                                                                      
Program terminated with signal SIGSEGV, Segmentation fault.                                                                                                                                                                                                                    
#0  0x00000000004018de in memset (__len=40, __ch=0, __dest=0x605ff0 <receiver>) at /usr/include/bits/string3.h:84                                                                                                                                                              
(gdb) bt
#0  0x00000000004018de in memset (__len=40, __ch=0, __dest=0x605ff0 <receiver>) at /usr/include/bits/string3.h:84
#1  process_notif_dev_connect (msg=msg@entry=0x7ffdfce9f040, device_index=device_index@entry=0x0, is_new_device=is_new_device@entry=0x0) at ltunify.c:398
#2  0x0000000000401bcc in do_read_skippy (fd=fd@entry=3, msg=msg@entry=0x7ffdfce9f040, exp_report_id=exp_report_id@entry=16 '\020', exp_sub_id=exp_sub_id@entry=128 '\200') at ltunify.c:439
#3  0x0000000000401da7 in set_register (fd=fd@entry=3, device_index=device_index@entry=255 '\377', address=address@entry=2 '\002', params=params@entry=0x7ffdfce9f080 "\002", res=res@entry=0x7ffdfce9f090, is_long_req=is_long_req@entry=false) at ltunify.c:501
#4  0x0000000000402a2d in set_short_register (res=0x7ffdfce9f090, params=0x7ffdfce9f080 "\002", address=2 '\002', device_index=255 '\377', fd=3) at ltunify.c:509
#5  get_all_devices (fd=fd@entry=3) at ltunify.c:729
#6  0x00000000004012bd in main (argc=<optimized out>, argv=<optimized out>) at ltunify.c:1265
```